### PR TITLE
Modern approach with JS loading

### DIFF
--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Figma + Vite + React + TS</title>
+    <script defer type="module" src="./index.tsx"></script>
   </head>
   <body>
     <div id="root">hey</div>
-    <script type="module" src="./index.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Put `<script>` to the end of HTML is old approach (to be sure that JS will be executed only when all HTML is loaded). With it JS file will be loaded a little later.

Modern approach is just add `defer` attribute which ask browser to run script only when HTML will be loaded.